### PR TITLE
Add workflow to publish bot to github container registry

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,28 @@
+name: Build and Publish Container Image
+
+on:
+  push:
+    tags: [v*.*.*]
+
+jobs:
+  build:
+    name: Build + Push
+    runs-on: ubuntu-latest
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Get version
+      run: echo "IMAGE_TAG=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
+
+    - name: Build Docker Image
+      run: docker build -t docker.pkg.github.com/${GITHUB_REPOSITORY}/mr-torrent:${IMAGE_TAG} .
+    
+    - name: Login
+      run: docker login -u publisher -p ${DOCKER_TOKEN} docker.pkg.github.com
+      env:
+        DOCKER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Push
+      run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/mr-torrent:${IMAGE_TAG}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -17,7 +17,7 @@ jobs:
 
 
     - name: Build Docker Image
-      run: docker build -t docker.pkg.github.com/${GITHUB_REPOSITORY}/mr-torrent:${IMAGE_TAG} .
+      run: docker build -t docker.pkg.github.com/${GITHUB_REPOSITORY}/discord-bot:${IMAGE_TAG} .
     
     - name: Login
       run: docker login -u publisher -p ${DOCKER_TOKEN} docker.pkg.github.com
@@ -25,4 +25,4 @@ jobs:
         DOCKER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Push
-      run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/mr-torrent:${IMAGE_TAG}
+      run: docker push docker.pkg.github.com/${GITHUB_REPOSITORY}/discord-bot:${IMAGE_TAG}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ praw==7.0.0
 prawcore==1.3.0
 numpy==1.18.4
 num2words==0.5.10
-compuglobal==0.2.3
+compuglobal==0.2.5


### PR DESCRIPTION
This workflow publishes a containerized version of the app to your personal github container registry.

If desired you can change the `discord-bot` in the workflow to something different, it will be what the image is called in your registry.

To publish, you have to create a release (tag) called `vX.X.X` and then the image will be tagged with the version `X.X.X`.